### PR TITLE
Add workaround for shoulda-matchers#1067

### DIFF
--- a/spec/models/tournament_spec.rb
+++ b/spec/models/tournament_spec.rb
@@ -3,10 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe Tournament, type: :model do
-  before do
-    @tournament = create(:tournament)
-  end
-
   describe 'validation' do
     it { should validate_presence_of :name }
     it { should validate_presence_of :code }
@@ -19,11 +15,13 @@ RSpec.describe Tournament, type: :model do
   end
 
   describe 'initialization' do
+    subject { create(:tournament) }
+
     it 'should have a code' do
-      expect(@tournament.code.length).to be(6)
+      expect(subject.code.length).to be(6)
     end
     it 'should be public' do
-      expect(@tournament.public).to be(true)
+      expect(subject.public).to be(true)
     end
   end
 


### PR DESCRIPTION
https://github.com/thoughtbot/shoulda-matchers/issues/1067
This issue led to the failure of the solution I implemented before in 8f88362264f3da5c06cc6b4924f98745fb764a72.
Because of it shoulda-matchers will just ignore the given record for the
validation check and just take the first existing one which in this case
can still contain a only-digits code, because it was generated in the
before-block.